### PR TITLE
Make read_json_value handle "true" and "false"

### DIFF
--- a/lib/couch_docs/design_directory.rb
+++ b/lib/couch_docs/design_directory.rb
@@ -56,7 +56,14 @@ module CouchDocs
     end
 
     def read_json_value(filename)
-      JSON.parse(File.new(filename).read)
+      filedata = File.new(filename).read
+      if filedata == "false"
+        false
+      elsif filedata == "true"
+        true
+      else
+        JSON.parse(filedata)
+      end
     end
 
     def read_js_value(filename)


### PR DESCRIPTION
When I was attempting to push my docs back to CouchDB, I found that
some of my design documents had certain properties serialized as
literally "false" or "true". I don't necessarily disagree with that,
but then the JSON parser complains. So this makes it return false or
true when that's all in the file, which makes my docs import as
expected.

If there's a cleaner way to fix this, please let me know and I'll
submit a better patch :)
